### PR TITLE
Enforce timestamp w/ timezones

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,12 @@ cache:
   directories:
     - $HOME/.pip-cache/
 
+env:
+  - TZ=UTC
+  - TZ=US/Eastern
+  - TZ=Europe/Amsterdam
+  - TZ=Africa/Johannesburg
+
 services:
   - redis-server
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -151,8 +151,8 @@ endpoint with ``--tcp-endpoint=tcp:8080:interface=127.0.0.1`` as an example
 JSON is used for the socket protocol. It uses ``\r\n`` as a delimiter
 
 .. note::   The timestamp values are all in ISO 8601 format. Timezone naive
-            timestamps are assumed to be in the timezone that Portia is
-            configured to run in. The default timezone is UTC.
+            timestamps are assumed to be in UTC and will be stored internally
+            as such.
 
 Get
 ---

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -151,7 +151,8 @@ endpoint with ``--tcp-endpoint=tcp:8080:interface=127.0.0.1`` as an example
 JSON is used for the socket protocol. It uses ``\r\n`` as a delimiter
 
 .. note::   The timestamp values are all in ISO 8601 format. Timezone naive
-            timestamps are assumed to be UTC and stored as UTC internally.
+            timestamps are assumed to be in the timezone that Portia is
+            configured to run in. The default timezone is UTC.
 
 Get
 ---

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -150,6 +150,9 @@ endpoint with ``--tcp-endpoint=tcp:8080:interface=127.0.0.1`` as an example
 
 JSON is used for the socket protocol. It uses ``\r\n`` as a delimiter
 
+.. note::   The timestamp values are all in ISO 8601 format. Timezone naive
+            timestamps are assumed to be UTC and stored as UTC internally.
+
 Get
 ---
 

--- a/portia/cli.py
+++ b/portia/cli.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import sys
-import json
+import pytz
 import pkg_resources
 
 from twisted.python import log
@@ -38,12 +38,16 @@ def main():
                       'portia', 'assets/mappings/*.mapping.json'),
               ),
               multiple=True)
+@click.option('--timezone',
+              default='UTC',
+              help=('The http://pythonhosted.org/pytz/ timezone to store '
+                    'timestamps in. (defaults to UTC)'))
 @click.option('--logfile',
               help='Where to log output to.',
               type=click.File('a'),
               default=sys.stdout)
 def run(redis_uri, web, web_endpoint, tcp, tcp_endpoint,
-        prefix, mappings_path, logfile):
+        prefix, mappings_path, timezone, logfile):
     from .utils import (
         start_redis, start_webserver, start_tcpserver,
         compile_network_prefix_mappings)
@@ -52,7 +56,8 @@ def run(redis_uri, web, web_endpoint, tcp, tcp_endpoint,
     d = start_redis(redis_uri)
     d.addCallback(
         Portia, prefix=prefix,
-        network_prefix_mapping=compile_network_prefix_mappings(mappings_path))
+        network_prefix_mapping=compile_network_prefix_mappings(mappings_path),
+        timezone=pytz.timezone(timezone))
 
     def start_servers(portia):
         callbacks = []

--- a/portia/cli.py
+++ b/portia/cli.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import sys
-import pytz
 import pkg_resources
 
 from twisted.python import log

--- a/portia/cli.py
+++ b/portia/cli.py
@@ -38,16 +38,12 @@ def main():
                       'portia', 'assets/mappings/*.mapping.json'),
               ),
               multiple=True)
-@click.option('--timezone',
-              default='UTC',
-              help=('The http://pythonhosted.org/pytz/ timezone to store '
-                    'timestamps in. (defaults to UTC)'))
 @click.option('--logfile',
               help='Where to log output to.',
               type=click.File('a'),
               default=sys.stdout)
 def run(redis_uri, web, web_endpoint, tcp, tcp_endpoint,
-        prefix, mappings_path, timezone, logfile):
+        prefix, mappings_path, logfile):
     from .utils import (
         start_redis, start_webserver, start_tcpserver,
         compile_network_prefix_mappings)
@@ -56,8 +52,7 @@ def run(redis_uri, web, web_endpoint, tcp, tcp_endpoint,
     d = start_redis(redis_uri)
     d.addCallback(
         Portia, prefix=prefix,
-        network_prefix_mapping=compile_network_prefix_mappings(mappings_path),
-        timezone=pytz.timezone(timezone))
+        network_prefix_mapping=compile_network_prefix_mappings(mappings_path))
 
     def start_servers(portia):
         callbacks = []

--- a/portia/portia.py
+++ b/portia/portia.py
@@ -22,20 +22,18 @@ class Portia(object):
         'ported-to',
     ])
 
-    def __init__(self, redis, prefix="portia:", network_prefix_mapping=None,
-                 timezone=utc):
+    def __init__(self, redis, prefix="portia:", network_prefix_mapping=None):
         self.redis = redis
         self.prefix = prefix
         self.network_prefix_mapping = network_prefix_mapping or {}
-        self.timezone = timezone
 
-    def local_time(self, timestamp):
+    def to_utc(self, timestamp):
         if timestamp.tzinfo:
-            return timestamp.astimezone(self.timezone)
-        return timestamp.replace(tzinfo=self.timezone)
+            return timestamp.astimezone(utc)
+        return timestamp.replace(tzinfo=utc)
 
     def now(self):
-        return self.local_time(datetime.now())
+        return self.to_utc(datetime.now())
 
     def key(self, *parts):
         return '%s%s' % (self.prefix, ':'.join(parts))
@@ -131,7 +129,7 @@ class Portia(object):
         d.addCallback(lambda key: self.redis.hmset(
             self.key(msisdn), {
                 key: value,
-                '%s-timestamp' % (key,): timestamp.isoformat(),
+                '%s-timestamp' % (key,): self.to_utc(timestamp).isoformat(),
             }))
         return d
 

--- a/portia/portia.py
+++ b/portia/portia.py
@@ -50,7 +50,7 @@ class Portia(object):
         return timestamp.replace(tzinfo=self.timezone)
 
     def now(self):
-        return self.to_utc(datetime.now())
+        return self.to_utc(datetime.utcnow())
 
     def key(self, *parts):
         return '%s%s' % (self.prefix, ':'.join(parts))

--- a/portia/portia.py
+++ b/portia/portia.py
@@ -1,11 +1,27 @@
 import csv
-from datetime import datetime
+from datetime import datetime, tzinfo, timedelta
 
 from twisted.internet.defer import gatherResults, succeed, maybeDeferred
 
-from pytz import utc
-
 from .exceptions import PortiaException
+
+
+class UTC(tzinfo):
+    """
+    UTC implementation taken from Python's docs.
+    """
+
+    def __repr__(self):
+        return "<UTC>"
+
+    def utcoffset(self, dt):
+        return timedelta(0)
+
+    def tzname(self, dt):
+        return "UTC"
+
+    def dst(self, dt):
+        return timedelta(0)
 
 
 class Portia(object):
@@ -26,11 +42,12 @@ class Portia(object):
         self.redis = redis
         self.prefix = prefix
         self.network_prefix_mapping = network_prefix_mapping or {}
+        self.timezone = UTC()
 
     def to_utc(self, timestamp):
         if timestamp.tzinfo:
-            return timestamp.astimezone(utc)
-        return timestamp.replace(tzinfo=utc)
+            return timestamp.astimezone(self.timezone)
+        return timestamp.replace(tzinfo=self.timezone)
 
     def now(self):
         return self.to_utc(datetime.now())

--- a/portia/protocol.py
+++ b/portia/protocol.py
@@ -10,21 +10,6 @@ from twisted.protocols.basic import LineReceiver
 from .exceptions import JsonProtocolException
 
 
-class UTC(tzinfo):
-
-    def __repr__(self):
-        return "<UTC>"
-
-    def utcoffset(self, dt):
-        return timedelta(0)
-
-    def tzname(self, dt):
-        return "UTC"
-
-    def dst(self, dt):
-        return timedelta(0)
-
-
 class JsonProtocol(LineReceiver):
 
     version = '0.1.0'
@@ -92,12 +77,9 @@ class JsonProtocol(LineReceiver):
 
     def handle_annotate(self, msisdn, key, value, timestamp=None):
         if timestamp:
-            ts = dateutil.parser.parse(timestamp)
-            tzinfo = ts.tzinfo
-            if tzinfo is None or tzinfo.utcoffset(ts) is None:
-                ts = ts.replace(tzinfo=UTC())
+            ts = self.portia.local_time(dateutil.parser.parse(timestamp))
         else:
-            ts = None
+            ts = self.portia.now()
         return self.portia.annotate(msisdn, key, value, timestamp=ts)
 
     def handle_resolve(self, msisdn):

--- a/portia/protocol.py
+++ b/portia/protocol.py
@@ -1,5 +1,4 @@
 import json
-from datetime import tzinfo, timedelta
 
 import dateutil.parser
 
@@ -77,7 +76,7 @@ class JsonProtocol(LineReceiver):
 
     def handle_annotate(self, msisdn, key, value, timestamp=None):
         if timestamp:
-            ts = self.portia.local_time(dateutil.parser.parse(timestamp))
+            ts = self.portia.to_utc(dateutil.parser.parse(timestamp))
         else:
             ts = self.portia.now()
         return self.portia.annotate(msisdn, key, value, timestamp=ts)

--- a/portia/tests/test_portia.py
+++ b/portia/tests/test_portia.py
@@ -131,7 +131,8 @@ class PortiaTest(TestCase):
     @inlineCallbacks
     def test_resolve_observation(self):
         yield self.portia.annotate(
-            '27123456789', 'observed-network', 'MNO')
+            '27123456789', 'observed-network', 'MNO',
+            timestamp=datetime.now())
         result = yield self.portia.resolve('27123456789')
         self.assertEqual(result['network'], 'MNO')
         self.assertEqual(result['strategy'], 'observed-network')

--- a/portia/tests/test_portia.py
+++ b/portia/tests/test_portia.py
@@ -45,7 +45,7 @@ class PortiaTest(TestCase):
     @inlineCallbacks
     def test_remove_imported_record(self):
         msisdn = yield self.portia.import_porting_record(
-            '27123456789', 'DONOR', 'RECIPIENT', datetime.now().date())
+            '27123456789', 'DONOR', 'RECIPIENT', datetime.now())
         self.assertTrue((yield self.portia.get_annotations(msisdn)))
         self.assertTrue(
             (yield self.portia.remove_annotations(
@@ -72,9 +72,9 @@ class PortiaTest(TestCase):
             '27123456789')
         self.assertEqual(observation, {
             'ported-to': 'MNO',
-            'ported-to-timestamp': timestamp1.isoformat(),
+            'ported-to-timestamp': self.portia.to_utc(timestamp1).isoformat(),
             'X-foo': 'bar',
-            'X-foo-timestamp': timestamp2.isoformat()
+            'X-foo-timestamp': self.portia.to_utc(timestamp2).isoformat()
         })
 
     @inlineCallbacks
@@ -92,7 +92,7 @@ class PortiaTest(TestCase):
             '27123456789')
         self.assertEqual(observation, {
             'X-foo': 'bar',
-            'X-foo-timestamp': timestamp.isoformat()
+            'X-foo-timestamp': self.portia.to_utc(timestamp).isoformat()
         })
 
     @inlineCallbacks
@@ -108,7 +108,8 @@ class PortiaTest(TestCase):
             (yield self.portia.read_annotation('27123456789', 'ported-to')),
             {
                 'ported-to': 'MNO',
-                'ported-to-timestamp': timestamp.isoformat(),
+                'ported-to-timestamp': self.portia.to_utc(
+                    timestamp).isoformat(),
             })
 
     @inlineCallbacks

--- a/portia/tests/test_protocol.py
+++ b/portia/tests/test_protocol.py
@@ -129,20 +129,23 @@ class ProtocolTest(TestCase):
     @inlineCallbacks
     def test_annotate(self):
         timestamp = parse('2015-10-20T22:56:15.894220+00:00')
-        result = yield self.send_command('annotate', msisdn='27123456789',
-                                         key='X-Foo', value='Bar',
-                                         timestamp=timestamp.isoformat())
+        result = yield self.send_command(
+            'annotate', msisdn='27123456789',
+            key='X-Foo', value='Bar',
+            timestamp=timestamp.isoformat())
         self.assertEqual(result['status'], 'ok')
         entry = yield self.portia.read_annotation('27123456789', 'X-Foo')
         self.assertEqual(entry, {
             'X-Foo': 'Bar',
-            'X-Foo-timestamp': timestamp.isoformat(),
+            'X-Foo-timestamp': self.portia.local_time(timestamp).isoformat(),
         })
 
     @inlineCallbacks
     def test_resolve_observed_network(self):
-        result = yield self.send_command('annotate', msisdn='27123456789',
-                                         key='observed-network', value='MNO')
+        result = yield self.send_command(
+            'annotate', msisdn='27123456789',
+            key='observed-network', value='MNO',
+            timestamp=self.portia.now().now().isoformat())
         result = yield self.send_command('resolve', msisdn='27123456789')
         response = result['response']
         self.assertEqual(response['network'], 'MNO')
@@ -150,8 +153,10 @@ class ProtocolTest(TestCase):
 
     @inlineCallbacks
     def test_resolve_ported_network(self):
-        result = yield self.send_command('annotate', msisdn='27123456789',
-                                         key='ported-to', value='MNO')
+        result = yield self.send_command(
+            'annotate', msisdn='27123456789',
+            key='ported-to', value='MNO',
+            timestamp=self.portia.now().isoformat())
         result = yield self.send_command('resolve', msisdn='27123456789')
         response = result['response']
         self.assertEqual(response['network'], 'MNO')

--- a/portia/tests/test_protocol.py
+++ b/portia/tests/test_protocol.py
@@ -2,6 +2,8 @@ import json
 import pkg_resources
 from datetime import datetime
 
+from dateutil.parser import parse
+
 from twisted.trial.unittest import TestCase
 from twisted.internet import reactor
 from twisted.internet.defer import inlineCallbacks, maybeDeferred, Deferred
@@ -126,7 +128,7 @@ class ProtocolTest(TestCase):
 
     @inlineCallbacks
     def test_annotate(self):
-        timestamp = datetime.utcnow()
+        timestamp = parse('2015-10-20T22:56:15.894220+00:00')
         result = yield self.send_command('annotate', msisdn='27123456789',
                                          key='X-Foo', value='Bar',
                                          timestamp=timestamp.isoformat())
@@ -161,3 +163,20 @@ class ProtocolTest(TestCase):
         response = result['response']
         self.assertEqual(response['network'], 'VODACOM')
         self.assertEqual(response['strategy'], 'prefix-guess')
+
+    @inlineCallbacks
+    def test_annotate_timestamp_with_timezone(self):
+        timestamp_za = parse('2015-10-20T23:56:15.894220+02:00')
+        timestamp_utc = parse('2015-10-20T22:56:15.894220+00:00')
+        yield self.send_command('annotate', msisdn='27123456789',
+                                key='observed-network',
+                                value='za-network',
+                                timestamp=timestamp_za.isoformat())
+        yield self.send_command('annotate', msisdn='27123456789',
+                                key='observed-network',
+                                value='utc-network',
+                                timestamp=timestamp_utc.isoformat())
+        result = yield self.send_command('resolve', msisdn='27123456789')
+        # NOTE: We're checking the timezone here, 22pm in +00:00 is more
+        #       recent than 23pm in +02:00
+        self.assertEqual(result['response']['network'], 'utc-network')

--- a/portia/tests/test_protocol.py
+++ b/portia/tests/test_protocol.py
@@ -123,7 +123,7 @@ class ProtocolTest(TestCase):
         result = yield self.send_command('get', msisdn='27123456789')
         self.assertEqual(result['response'], {
             'ported-to': 'MNO',
-            'ported-to-timestamp': timestamp.isoformat(),
+            'ported-to-timestamp': self.portia.to_utc(timestamp).isoformat(),
         })
 
     @inlineCallbacks
@@ -137,7 +137,7 @@ class ProtocolTest(TestCase):
         entry = yield self.portia.read_annotation('27123456789', 'X-Foo')
         self.assertEqual(entry, {
             'X-Foo': 'Bar',
-            'X-Foo-timestamp': self.portia.local_time(timestamp).isoformat(),
+            'X-Foo-timestamp': self.portia.to_utc(timestamp).isoformat(),
         })
 
     @inlineCallbacks

--- a/portia/tests/test_web.py
+++ b/portia/tests/test_web.py
@@ -61,9 +61,9 @@ class PortiaServerTest(TestCase):
         data = yield response.json()
         self.assertEqual(data, {
             'ported-to': 'MNO2',
-            'ported-to-timestamp': timestamp.isoformat(),
+            'ported-to-timestamp': self.portia.to_utc(timestamp).isoformat(),
             'ported-from': 'MNO1',
-            'ported-from-timestamp': timestamp.isoformat(),
+            'ported-from-timestamp': self.portia.to_utc(timestamp).isoformat(),
         })
 
     @inlineCallbacks
@@ -75,7 +75,7 @@ class PortiaServerTest(TestCase):
         data = yield response.json()
         self.assertEqual(data, {
             'ported-to': 'MNO2',
-            'ported-to-timestamp': timestamp.isoformat(),
+            'ported-to-timestamp': self.portia.to_utc(timestamp).isoformat(),
         })
 
     @inlineCallbacks

--- a/portia/tests/test_web.py
+++ b/portia/tests/test_web.py
@@ -116,7 +116,8 @@ class PortiaServerTest(TestCase):
     @inlineCallbacks
     def test_resolve_observation(self):
         yield self.portia.annotate(
-            '27123456789', 'observed-network', 'MNO')
+            '27123456789', 'observed-network', 'MNO',
+            timestamp=datetime.now())
         response = yield self.request('GET', '/resolve/27123456789')
         result = yield response.json()
         self.assertEqual(result['network'], 'MNO')

--- a/portia/web.py
+++ b/portia/web.py
@@ -69,6 +69,6 @@ class PortiaWebServer(object):
             request.setResponseCode(400)
             return json.dumps('No content supplied')
 
-        d = self.portia.annotate(msisdn, key, content)
+        d = self.portia.annotate(msisdn, key, content, self.portia.now())
         d.addCallback(lambda _: json.dumps(content))
         return d

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ txredisapi==1.3
 click==5.1
 hiredis==0.2.0
 python-dateutil==1.5
-pytz==2015.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ txredisapi==1.3
 click==5.1
 hiredis==0.2.0
 python-dateutil==1.5
+pytz==2015.6


### PR DESCRIPTION
Naive datetimes are now automatically assumed to be UTC. If an ISO8601 date is provided with timezone information it will be stored internally in the UTC timezone.
